### PR TITLE
feat: promote npm edge tag to latest when prerelease is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,33 @@ name: Publish to NPM
 on:
   release:
     types:
-      - created
-
+      - published
+      - released
 jobs:
+  # When a prerelease is promoted to a full release, update the npm latest tag
+  promote:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install node 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+      - name: Promote edge to latest
+        run: |
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          PACKAGE=$(node -p "require('./package.json').name")
+          npm dist-tag add "$PACKAGE@$VERSION" latest
+          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}
+
   deploy:
+    if: github.event.action == 'published'
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm


### PR DESCRIPTION
## Problem

When a release is published as a prerelease, it gets tagged as `edge` on npm. Later, when the release is promoted to a full release in GitHub, the npm `latest` tag doesn't update because the workflow only triggered on `published`.

## Solution

- Added `released` to the release workflow trigger types
- New lightweight `promote` job that only runs `npm dist-tag add latest` — no install, no lint, no tests, no re-publish
- Only fires on the `released` event (when a prerelease is promoted to full release)
- Existing `deploy` job is now explicitly gated to `published` events only (no behavior change)
- Uses `TAG_NAME` env var instead of direct interpolation to prevent script injection

## Flow

1. Publish as prerelease → full pipeline runs, publishes with `edge` tag (unchanged)
2. Promote release → uncheck prerelease → `promote` job runs, points `latest` to that version (~15s)

The `dist-tag add` command is idempotent, so if both `published` and `released` fire on a fresh non-prerelease publish, the redundant promote is harmless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the GitHub Actions release workflow and only adjust npm dist-tags/publish triggers; main risk is an incorrect tag update if the event/version parsing is wrong.
> 
> **Overview**
> Updates the release workflow to trigger on both `published` and `released` events.
> 
> Adds a new `promote` job that runs only on `released` to move the npm `latest` dist-tag to the release version (without re-publishing), and gates the existing `deploy` publish pipeline to run only on `published`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6f436866fd78698984cd7ca0a6289c14801fbae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->